### PR TITLE
lint blocking calls

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,11 @@
     "exclude": ["CHANGELOG.md"]
   },
   "lint": {
-    "exclude": ["tests/"]
+    "exclude": ["tests/"],
+    "rules": {
+      "include": [
+        "no-sync-fn-in-async-fn"
+      ]
+    }
   }
 }

--- a/src/import_map.ts
+++ b/src/import_map.ts
@@ -32,7 +32,7 @@ async function readFromJson(path: string): Promise<Maybe<ImportMap>> {
   const inner = await parseFromJson(
     specifier,
     // deno-lint-ignore no-explicit-any
-    parseJsonc(Deno.readTextFileSync(path)) as any,
+    parseJsonc(await Deno.readTextFile(path)) as any,
   );
   const json = JSON.parse(inner.toJSON()) as ImportMapJson;
   if (!json.imports) {

--- a/src/update_test.ts
+++ b/src/update_test.ts
@@ -115,7 +115,7 @@ describe("applyToModule", () => {
     updates = await DependencyUpdate.collect(
       "./tests/direct-import/mod.ts",
     );
-    content = Deno.readTextFileSync("./tests/direct-import/mod.ts");
+    content = await Deno.readTextFile("./tests/direct-import/mod.ts");
   });
   it("https://deno.land/x/deno_graph", () => {
     const update = updates.find((update) =>


### PR DESCRIPTION
This is a lint I added a while to back to deno lint, so I'm biased, thought its nice to try it  on a real project, it only caught one instance in import_map.ts, the other one is in tests so its not a big deal.

https://lint.deno.land/?q=no-sync&all=on#no-sync-fn-in-async-fn